### PR TITLE
Handled overlaping event bugs with better comparison logic

### DIFF
--- a/src/pages/retreat/[id].tsx
+++ b/src/pages/retreat/[id].tsx
@@ -35,13 +35,184 @@ function Content({
   counter: number;
   retreatId: string;
 }) {
+  const StrToMinutes = (timeStr: string): number => {
+    const parts = timeStr.match(/(\d+):(\d+) (\w+)/);
+    // if (!parts) {
+    //   throw new Error('Invalid time format');
+    // }
+    // Extract hours, minutes, and the period (AM/PM)
+    let [_, hours, minutes, period] = parts!;
+    // Get hours in 24hr format
+    const hoursNumber = ((parseInt(hours!) % 12) + (period!.toLowerCase() === 'pm' ? 12 : 0)) % 24;
+    const minutesNumber = parseInt(minutes!);
+    // Calculate total minutes
+    return hoursNumber * 60 + minutesNumber;
+  }
+  const DayComparator = (a: EventWithStamp, b: EventWithStamp): number => {
+    const afrom = StrToMinutes(a.from);
+    const bfrom = StrToMinutes(b.from);
+    if (afrom == bfrom) {
+      const ato = StrToMinutes(a.to);
+      const bto = StrToMinutes(b.to);
+      return bto - ato; // descending 'to's otherwise
+    }
+    return afrom - bfrom; // ascending 'from's first
+  }
   let eventsByDay: EventWithStamp[][] = [[], [], [], []];
   for (const event of events) {
     const { dates } = event;
     for (const date of dates) {
       const { from, to, day } = date;
       eventsByDay[day - 1]!.push({ event, from, to });
+      console.log(from)
     }
+  }
+  for (const dayEvents of eventsByDay) {
+    dayEvents.sort(DayComparator)
+  }
+
+  const MapEventsForDay = (day: number) => (einfo: EventWithStamp, index: number, arr) => {
+    if (counter > 0) {
+      counter--;
+      return <></>;
+    }
+    const { event: currEvent, from: currFrom, to: currTo } = einfo;
+    const dateObject: DateObject = {
+      day,
+      from: currFrom,
+      to: currTo,
+    };
+
+    const totalExpense = currEvent.expenses.reduce(
+      (acc: any, cv: any) => acc + cv.cost,
+      0,
+    );
+
+    const event: EventWithStamp = {
+      event: currEvent,
+      from: currFrom,
+      to: currTo,
+    };
+    if (index < arr.length - 1) {
+      const nextEventsArray = [];
+      var {
+        event: afterEvent,
+        from: nextFrom,
+        to: nextTo,
+      } = eventsByDay[day - 1]![index + 1]!;
+      // Check if the next event's "from" time is between the current event's from and to
+      // appends every additional case where next event's time is between original "from" and "to"
+      let prevTop: number | null = null;
+      while (
+        index < arr.length - 1 &&
+        StrToMinutes(nextFrom) &&
+        StrToMinutes(nextFrom) >= StrToMinutes(currFrom) &&
+        StrToMinutes(nextFrom) < StrToMinutes(currTo)
+      ) {
+        const nextDateObject: DateObject = {
+          day: 1, 
+          from: nextFrom,
+          to: nextTo,
+        };
+
+        const nextTotalExpense = currEvent.expenses.reduce(
+          (acc: any, cv: any) => acc + cv.cost,
+          0,
+        );
+
+        const nextEventObject: Event = {
+          ...afterEvent,
+          dates: [nextDateObject],
+        };
+
+        var topY = computeHeight(nextFrom, currFrom, screen.height);
+        // if (nextEventsArray.length > 0) {
+        if (prevTop) {
+          // const prevTotalTopY = nextEventsArray.reduce(
+          //   (acc, nt) =>
+          //     acc -
+          //     nt.topY +
+          //     computeHeight(
+          //       nt.nextDateObject.from,
+          //       nt.nextDateObject.to,
+          //       screen.height,
+          //     ),
+          //   0,
+          // );
+          // topY += prevTotalTopY;
+          topY += prevTop;
+        }
+        nextEventsArray.push({
+          nextDateObject,
+          nextTotalExpense,
+          nextEventObject,
+          topY,
+        });
+        prevTop = topY;
+        index++;
+        counter++;
+        if (index + 1 === arr.length) {
+          break;
+        }
+        var {
+          event: afterEvent,
+          from: nextFrom,
+          to: nextTo,
+        } = eventsByDay[day - 1]![index + 1]!;
+      }
+      return (
+        <Box display={"flex"} key={index}>
+          {nextEventsArray.length === 0 ? (
+            <CalendarCard
+              retreatId={retreatId}
+              expenseTotal={totalExpense}
+              date={dateObject}
+              event={event.event}
+              width={207}
+            />
+          ) : (
+            <>
+              <CalendarCard
+                expenseTotal={totalExpense}
+                date={dateObject}
+                event={event.event}
+                width={103}
+                retreatId={retreatId}
+              />
+              <Box>
+                {nextEventsArray.map(
+                  (nextEvent: any, index) => {
+                    return (
+                      <CalendarCard
+                        right={true}
+                        retreatId={retreatId}
+                        key={index}
+                        expenseTotal={
+                          nextEvent.nextTotalExpense
+                        }
+                        date={nextEvent.nextDateObject}
+                        event={nextEvent.nextEventObject}
+                        width={103}
+                      />
+                    );
+                  },
+                )}
+              </Box>
+            </>
+          )}
+        </Box>
+      );
+    }
+    return (
+      <CalendarCard
+        retreatId={retreatId}
+        key={index}
+        expenseTotal={totalExpense}
+        date={dateObject}
+        event={event.event}
+        width={207}
+      />
+    );
   }
 
   return (
@@ -69,146 +240,7 @@ function Content({
               </Text>
               <Box display={"flex"} position={"relative"}>
                 <Box marginRight={"34px"} minW={"180px"}>
-                  {eventsByDay[day - 1]!.map((einfo, index: number, arr) => {
-                    if (counter > 0) {
-                      counter--;
-                      return <></>;
-                    }
-                    const { event: currEvent, from, to } = einfo;
-                    const dateObject: DateObject = {
-                      day,
-                      from,
-                      to,
-                    };
-
-                    const totalExpense = currEvent.expenses.reduce(
-                      (acc: any, cv: any) => acc + cv.cost,
-                      0,
-                    );
-
-                    const event: EventWithStamp = {
-                      event: currEvent,
-                      from: from,
-                      to: to,
-                    };
-                    if (index < arr.length - 1) {
-                      const nextEventsArray = [];
-                      var {
-                        event: afterEvent,
-                        from: nextFrom,
-                        to: nextTo,
-                      } = eventsByDay[day - 1]![index + 1]!;
-                      // Check if the next event's "from" time is between the current event's from and to
-                      // appends every additional case where next event's time is between original "from" and "to"
-                      while (
-                        index < arr.length - 1 &&
-                        nextFrom &&
-                        nextFrom >= from &&
-                        nextFrom <= to
-                      ) {
-                        const nextDateObject: DateObject = {
-                          day: 1,
-                          from: nextFrom,
-                          to: nextTo,
-                        };
-
-                        const nextTotalExpense = currEvent.expenses.reduce(
-                          (acc: any, cv: any) => acc + cv.cost,
-                          0,
-                        );
-
-                        const nextEventObject: Event = {
-                          ...afterEvent,
-                          dates: [nextDateObject],
-                        };
-
-                        var topY = computeHeight(nextFrom, from, screen.height);
-                        if (nextEventsArray.length > 0) {
-                          const prevTotalTopY = nextEventsArray.reduce(
-                            (acc, nt) =>
-                              acc -
-                              nt.topY +
-                              computeHeight(
-                                nt.nextDateObject.from,
-                                nt.nextDateObject.to,
-                                screen.height,
-                              ),
-                            0,
-                          );
-                          topY += prevTotalTopY;
-                        }
-                        nextEventsArray.push({
-                          nextDateObject,
-                          nextTotalExpense,
-                          nextEventObject,
-                          topY,
-                        });
-                        index++;
-                        counter++;
-                        if (index + 1 === arr.length) {
-                          break;
-                        }
-                        var {
-                          event: afterEvent,
-                          from: nextFrom,
-                          to: nextTo,
-                        } = eventsByDay[day - 1]![index + 1]!;
-                      }
-                      return (
-                        <Box display={"flex"} key={index}>
-                          {nextEventsArray.length === 0 ? (
-                            <CalendarCard
-                              retreatId={retreatId}
-                              expenseTotal={totalExpense}
-                              date={dateObject}
-                              event={event.event}
-                              width={207}
-                            />
-                          ) : (
-                            <>
-                              <CalendarCard
-                                expenseTotal={totalExpense}
-                                date={dateObject}
-                                event={event.event}
-                                width={103}
-                                retreatId={retreatId}
-                              />
-                              <Box>
-                                {nextEventsArray.map(
-                                  (nextEvent: any, index) => {
-                                    return (
-                                      <CalendarCard
-                                        right={true}
-                                        retreatId={retreatId}
-                                        key={index}
-                                        expenseTotal={
-                                          nextEvent.nextTotalExpense
-                                        }
-                                        date={nextEvent.nextDateObject}
-                                        event={nextEvent.nextEventObject}
-                                        width={103}
-                                      />
-                                    );
-                                  },
-                                )}
-                              </Box>
-                            </>
-                          )}
-                        </Box>
-                      );
-                    }
-
-                    return (
-                      <CalendarCard
-                        retreatId={retreatId}
-                        key={index}
-                        expenseTotal={totalExpense}
-                        date={dateObject}
-                        event={event.event}
-                        width={207}
-                      />
-                    );
-                  })}
+                  {eventsByDay[day - 1]!.map(MapEventsForDay(day))}
                 </Box>
                 {day !== 4 && (
                   <Box

--- a/src/pages/retreat/[id].tsx
+++ b/src/pages/retreat/[id].tsx
@@ -71,148 +71,138 @@ function Content({
     dayEvents.sort(DayComparator)
   }
 
-  const MapEventsForDay = (day: number) => (einfo: EventWithStamp, index: number, arr) => {
-    if (counter > 0) {
-      counter--;
-      return <></>;
-    }
-    const { event: currEvent, from: currFrom, to: currTo } = einfo;
-    const dateObject: DateObject = {
-      day,
-      from: currFrom,
-      to: currTo,
-    };
-
-    const totalExpense = currEvent.expenses.reduce(
-      (acc: any, cv: any) => acc + cv.cost,
-      0,
-    );
-
-    const event: EventWithStamp = {
-      event: currEvent,
-      from: currFrom,
-      to: currTo,
-    };
-    if (index < arr.length - 1) {
-      const nextEventsArray = [];
-      var {
-        event: afterEvent,
-        from: nextFrom,
-        to: nextTo,
-      } = eventsByDay[day - 1]![index + 1]!;
-      // Check if the next event's "from" time is between the current event's from and to
-      // appends every additional case where next event's time is between original "from" and "to"
-      let prevTop: number | null = null;
-      while (
-        index < arr.length - 1 &&
-        StrToMinutes(nextFrom) &&
-        StrToMinutes(nextFrom) >= StrToMinutes(currFrom) &&
-        StrToMinutes(nextFrom) < StrToMinutes(currTo)
-      ) {
-        const nextDateObject: DateObject = {
-          day: 1, 
-          from: nextFrom,
-          to: nextTo,
-        };
-
-        const nextTotalExpense = currEvent.expenses.reduce(
-          (acc: any, cv: any) => acc + cv.cost,
-          0,
-        );
-
-        const nextEventObject: Event = {
-          ...afterEvent,
-          dates: [nextDateObject],
-        };
-
-        var topY = computeHeight(nextFrom, currFrom, screen.height);
-        // if (nextEventsArray.length > 0) {
-        if (prevTop) {
-          // const prevTotalTopY = nextEventsArray.reduce(
-          //   (acc, nt) =>
-          //     acc -
-          //     nt.topY +
-          //     computeHeight(
-          //       nt.nextDateObject.from,
-          //       nt.nextDateObject.to,
-          //       screen.height,
-          //     ),
-          //   0,
-          // );
-          // topY += prevTotalTopY;
-          topY += prevTop;
-        }
-        nextEventsArray.push({
-          nextDateObject,
-          nextTotalExpense,
-          nextEventObject,
-          topY,
-        });
-        prevTop = topY;
-        index++;
-        counter++;
-        if (index + 1 === arr.length) {
-          break;
-        }
-        var {
-          event: afterEvent,
-          from: nextFrom,
-          to: nextTo,
-        } = eventsByDay[day - 1]![index + 1]!;
+  function MapEventsForDay(day: number) {
+    return function bruhEvent(einfo: EventWithStamp, index: number, arr: EventWithStamp[]) {
+      if (counter > 0) {
+        counter--;
+        return <></>;
       }
-      return (
-        <Box display={"flex"} key={index}>
-          {nextEventsArray.length === 0 ? (
-            <CalendarCard
-              retreatId={retreatId}
-              expenseTotal={totalExpense}
-              date={dateObject}
-              event={event.event}
-              width={207}
-            />
-          ) : (
-            <>
+      const { event: currEvent, from: currFrom, to: currTo } = einfo;
+      const dateObject: DateObject = {
+        day,
+        from: currFrom,
+        to: currTo,
+      };
+  
+      const totalExpense = currEvent.expenses.reduce(
+        (acc: any, cv: any) => acc + cv.cost,
+        0
+      );
+  
+      const event: EventWithStamp = {
+        event: currEvent,
+        from: currFrom,
+        to: currTo,
+      };
+      if (index < arr.length - 1) {
+        const nextEventsArray = [];
+        var {
+          event: afterEvent, from: nextFrom, to: nextTo,
+        } = eventsByDay[day - 1]![index + 1]!;
+        // Check if the next event's "from" time is between the current event's from and to
+        // appends every additional case where next event's time is between original "from" and "to"
+        let prevTop: number | null = null;
+        while (index < arr.length - 1 &&
+          StrToMinutes(nextFrom) &&
+          StrToMinutes(nextFrom) >= StrToMinutes(currFrom) &&
+          StrToMinutes(nextFrom) < StrToMinutes(currTo)) {
+          const nextDateObject: DateObject = {
+            day: 1,
+            from: nextFrom,
+            to: nextTo,
+          };
+  
+          const nextTotalExpense = currEvent.expenses.reduce(
+            (acc: any, cv: any) => acc + cv.cost,
+            0
+          );
+  
+          const nextEventObject: Event = {
+            ...afterEvent,
+            dates: [nextDateObject],
+          };
+  
+          var topY = computeHeight(nextFrom, currFrom, screen.height);
+          // if (nextEventsArray.length > 0) {
+          if (prevTop) {
+            // const prevTotalTopY = nextEventsArray.reduce(
+            //   (acc, nt) =>
+            //     acc -
+            //     nt.topY +
+            //     computeHeight(
+            //       nt.nextDateObject.from,
+            //       nt.nextDateObject.to,
+            //       screen.height,
+            //     ),
+            //   0,
+            // );
+            // topY += prevTotalTopY;
+            topY += prevTop;
+          }
+          nextEventsArray.push({
+            nextDateObject,
+            nextTotalExpense,
+            nextEventObject,
+            topY,
+          });
+          prevTop = topY;
+          index++;
+          counter++;
+          if (index + 1 === arr.length) {
+            break;
+          }
+          var {
+            event: afterEvent, from: nextFrom, to: nextTo,
+          } = eventsByDay[day - 1]![index + 1]!;
+        }
+        return (
+          <Box display={"flex"} key={index}>
+            {nextEventsArray.length === 0 ? (
               <CalendarCard
+                retreatId={retreatId}
                 expenseTotal={totalExpense}
                 date={dateObject}
                 event={event.event}
-                width={103}
-                retreatId={retreatId}
-              />
-              <Box>
-                {nextEventsArray.map(
-                  (nextEvent: any, index) => {
-                    return (
-                      <CalendarCard
-                        right={true}
-                        retreatId={retreatId}
-                        key={index}
-                        expenseTotal={
-                          nextEvent.nextTotalExpense
-                        }
-                        date={nextEvent.nextDateObject}
-                        event={nextEvent.nextEventObject}
-                        width={103}
-                      />
-                    );
-                  },
-                )}
-              </Box>
-            </>
-          )}
-        </Box>
+                width={207} />
+            ) : (
+              <>
+                <CalendarCard
+                  expenseTotal={totalExpense}
+                  date={dateObject}
+                  event={event.event}
+                  width={103}
+                  retreatId={retreatId} />
+                <Box>
+                  {nextEventsArray.map(
+                    (nextEvent: any, index) => {
+                      return (
+                        <CalendarCard
+                          right={true}
+                          retreatId={retreatId}
+                          key={index}
+                          expenseTotal={nextEvent.nextTotalExpense}
+                          date={nextEvent.nextDateObject}
+                          event={nextEvent.nextEventObject}
+                          width={103} />
+                      );
+                    }
+                  )}
+                </Box>
+              </>
+            )}
+          </Box>
+        );
+      }
+      return (
+        <CalendarCard
+          retreatId={retreatId}
+          key={index}
+          expenseTotal={totalExpense}
+          date={dateObject}
+          event={event.event}
+          width={207} />
       );
     }
-    return (
-      <CalendarCard
-        retreatId={retreatId}
-        key={index}
-        expenseTotal={totalExpense}
-        date={dateObject}
-        event={event.event}
-        width={207}
-      />
-    );
   }
 
   return (


### PR DESCRIPTION
Addresses #71 

In this PR:
- I extracted the giant mapping function before the final return statement in `retreat/[id].tsx` for better readability (imo)
- I turned a `<=` to a `<` to fix the falsely overlapping events bug
- I introduced a function to turn time-of-day strings into minutes for more reliable comparison
- I sorted the `eventsByDay` arrays to catch more edge cases with overlapping events
- I tried to simplify some logic in `retreat/[id].tsx:131`; it seems to be working fine for my testing, but it's worth a look

