### PR TITLE
Fix/retreat expenses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@trpc/server": "^10.34.0",
         "framer-motion": "^10.16.3",
         "lucia": "^2.7.4",
-        "mongoose": "^7.5.0",
+        "mongoose": "^7.6.8",
         "next": "13.4.x",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -2137,9 +2137,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
-      "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
+      "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -5406,9 +5406,9 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.0.tgz",
-      "integrity": "sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.1.tgz",
+      "integrity": "sha512-NBGA8AfJxGPeB12F73xXwozt8ZpeIPmCUeWRwl9xejozTXFes/3zaep9zhzs1B/nKKsw4P3I4iPfXl3K7s6g+Q==",
       "dependencies": {
         "bson": "^5.5.0",
         "mongodb-connection-string-url": "^2.6.0",
@@ -5455,13 +5455,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.4.tgz",
-      "integrity": "sha512-kadPkS/f5iZJrrMxxOvSoOAErXmdnb28lMvHmuYgmV1ZQTpRqpp132PIPHkJMbG4OC2H0eSXYw/fNzYTH+LUcw==",
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.8.tgz",
+      "integrity": "sha512-q9zAySH+UtOK5yonWyNcLfq3PxrY6s4gdta4qNGKNOE2yTVoY9FP4hQtvWYnv4rkdk7T8QmQMC7bbhJjDxIunw==",
       "dependencies": {
         "bson": "^5.5.0",
         "kareem": "2.5.1",
-        "mongodb": "5.9.0",
+        "mongodb": "5.9.1",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@trpc/server": "^10.34.0",
     "framer-motion": "^10.16.3",
     "lucia": "^2.7.4",
-    "mongoose": "^7.5.0",
+    "mongoose": "^7.6.8",
     "next": "13.4.x",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -51,6 +51,7 @@ export const expenseSchema = z.object({
   _id: z.string().optional(),
   name: z.string(),
   event: z.string().optional(),
+  eventId: z.string().optional(),
   type: expenseTypeSchema,
   cost: z.number(),
   numUnits: z.number().optional(),

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -48,6 +48,7 @@ export type DateObject = z.infer<typeof dateObjectSchema>;
 
 // Expense
 export const expenseSchema = z.object({
+  _id: z.string().optional(),
   name: z.string(),
   event: z.string().optional(),
   type: expenseTypeSchema,

--- a/src/components/NewExpenseForm.tsx
+++ b/src/components/NewExpenseForm.tsx
@@ -118,9 +118,9 @@ export const NewExpenseForm = ({
       return;
     }
     onCloseError();
-    // if (onCloseSide) {
-    //   onCloseSide();
-    // }
+    if (onCloseSide) {
+      onCloseSide();
+    }
     if (create) {
       if (retreatId) {
         await createExpense.mutate({ expenseDetails: state, retreatId });
@@ -128,25 +128,23 @@ export const NewExpenseForm = ({
         await createExpense.mutate({ expenseDetails: state });
       }
     } else {
-      if (selectedExpense && selectedExpense._id && !expenses) {
+      if (setExpenses && expenses) {
+        const updatedExpenses = expenses.map((e) =>
+          e === selectedExpense ? state : e,
+        );
+        setExpenses(updatedExpenses);
+        if (setSelectedExpense) {
+          setSelectedExpense(undefined);
+        }
+        dispatch({ type: "RESET" });
+        return;
+      } else if (selectedExpense && selectedExpense._id) {
         await updateExpense.mutate({ expense: state, expenseId: selectedExpense._id });
       }
-      if (selectedExpense && selectedExpense._id && expenses) {
-        await updateExpense.mutate({ expense: state, expenseId: selectedExpense._id });
-      }
-      // if (expenses && setExpenses) {
-      //   const updatedExpenses = expenses.map((e) =>
-      //   e === selectedExpense ? state : e,
-      //   );
-      //   setExpenses(updatedExpenses);
-      //   if (setSelectedExpense) {
-      //     setSelectedExpense(undefined);
-      //   }
-      // }
     }
-    // if (setExpenses && expenses) {
-    //   setExpenses([...expenses, state]);
-    // }
+    if (setExpenses && expenses) {
+      setExpenses([...expenses, state]);
+    }
     if (onCloseSide) {
       onCloseSide();
     }

--- a/src/components/NewExpenseForm.tsx
+++ b/src/components/NewExpenseForm.tsx
@@ -25,6 +25,7 @@ type NewExpenseFormProps = {
   selectedExpense: Expense | undefined;
   setSelectedExpense?: (t: Expense | undefined) => void;
   retreatId?: string;
+  thisEvent?: string;
 };
 
 type Action<T extends keyof Expense = keyof Expense> =
@@ -62,6 +63,7 @@ export const NewExpenseForm = ({
   selectedExpense,
   setSelectedExpense,
   retreatId,
+  thisEvent,
   ...rest
 }: NewExpenseFormProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -106,6 +108,11 @@ export const NewExpenseForm = ({
       trpcUtils.event.invalidate();
     },
   });
+  const updateExpenseByEvent = trpc.event.updateExpenseByEvent.useMutation({
+    onSuccess: () => {
+      trpcUtils.event.invalidate();
+    },
+  });
   const createExpense = trpc.event.createExpense.useMutation({
     onSuccess: () => {
       trpcUtils.event.invalidate();
@@ -138,6 +145,8 @@ export const NewExpenseForm = ({
         }
         dispatch({ type: "RESET" });
         return;
+      } else if (selectedExpense && selectedExpense._id && thisEvent) {
+        await updateExpenseByEvent.mutate({ expense: state, expenseId: selectedExpense._id, eventId: thisEvent });
       } else if (selectedExpense && selectedExpense._id) {
         await updateExpense.mutate({ expense: state, expenseId: selectedExpense._id });
       }

--- a/src/components/NewExpenseForm.tsx
+++ b/src/components/NewExpenseForm.tsx
@@ -128,19 +128,25 @@ export const NewExpenseForm = ({
         await createExpense.mutate({ expenseDetails: state });
       }
     } else {
-      if (expenses && setExpenses) {
-        const updatedExpenses = expenses.map((e) =>
-        e === selectedExpense ? state : e,
-        );
-        setExpenses(updatedExpenses);
-        if (setSelectedExpense) {
-          setSelectedExpense(undefined);
-        }
+      if (selectedExpense && selectedExpense._id && !expenses) {
+        await updateExpense.mutate({ expense: state, expenseId: selectedExpense._id });
       }
+      if (selectedExpense && selectedExpense._id && expenses) {
+        await updateExpense.mutate({ expense: state, expenseId: selectedExpense._id });
+      }
+      // if (expenses && setExpenses) {
+      //   const updatedExpenses = expenses.map((e) =>
+      //   e === selectedExpense ? state : e,
+      //   );
+      //   setExpenses(updatedExpenses);
+      //   if (setSelectedExpense) {
+      //     setSelectedExpense(undefined);
+      //   }
+      // }
     }
-    if (setExpenses && expenses) {
-      setExpenses([...expenses, state]);
-    }
+    // if (setExpenses && expenses) {
+    //   setExpenses([...expenses, state]);
+    // }
     if (onCloseSide) {
       onCloseSide();
     }

--- a/src/components/NewExpenseForm.tsx
+++ b/src/components/NewExpenseForm.tsx
@@ -24,6 +24,7 @@ type NewExpenseFormProps = {
   onCloseSide?: () => void;
   selectedExpense: Expense | undefined;
   setSelectedExpense?: (t: Expense | undefined) => void;
+  retreatId?: string;
 };
 
 type Action<T extends keyof Expense = keyof Expense> =
@@ -60,6 +61,7 @@ export const NewExpenseForm = ({
   onCloseSide,
   selectedExpense,
   setSelectedExpense,
+  retreatId,
   ...rest
 }: NewExpenseFormProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -99,11 +101,11 @@ export const NewExpenseForm = ({
   };
 
   const trpcUtils = trpc.useContext();
-  // const updateExpense = trpc.event.updateExpense.useMutation({
-  //   onSuccess: () => {
-  //     trpcUtils.event.invalidate();
-  //   },
-  // });
+  const updateExpense = trpc.event.updateExpense.useMutation({
+    onSuccess: () => {
+      trpcUtils.event.invalidate();
+    },
+  });
   const createExpense = trpc.event.createExpense.useMutation({
     onSuccess: () => {
       trpcUtils.event.invalidate();
@@ -120,7 +122,11 @@ export const NewExpenseForm = ({
     //   onCloseSide();
     // }
     if (create) {
-      await createExpense.mutate({ expenseDetails: state });
+      if (retreatId) {
+        await createExpense.mutate({ expenseDetails: state, retreatId });
+      } else {
+        await createExpense.mutate({ expenseDetails: state });
+      }
     } else {
       if (expenses && setExpenses) {
         const updatedExpenses = expenses.map((e) =>
@@ -271,21 +277,21 @@ export const NewExpenseForm = ({
             height="100px"
           />
         </FormControl> */}
+        <Button
+          width="100%"
+          height="50px"
+          bg="#FF6B6B"
+          color="white"
+          fontSize="18px"
+          fontWeight="500"
+          lineHeight="24px"
+          borderRadius="none"
+          onClick={handleApply}
+          marginTop="80px"
+        >
+          {create ? "Add Expense" : "Update Expense"}
+        </Button>
       </VStack>
-      <Button
-        width="100%"
-        height="50px"
-        bg="#FF6B6B"
-        color="white"
-        fontSize="18px"
-        fontWeight="500"
-        lineHeight="24px"
-        borderRadius="none"
-        onClick={handleApply}
-        marginBottom="50px"
-      >
-        {create ? "Add Expense" : "Update Expense"}
-      </Button>
     </VStack>
   );
 };

--- a/src/components/NewExpenseModal.tsx
+++ b/src/components/NewExpenseModal.tsx
@@ -16,6 +16,7 @@ type NewExpenseProps = {
   onClose: () => void;
   retreatId?: string;
   thisExpense: Expense | undefined;
+  thisEvent?: string;
 };
 
 export const NewExpenseModal = ({
@@ -23,6 +24,7 @@ export const NewExpenseModal = ({
   onClose,
   thisExpense,
   retreatId,
+  thisEvent
 }: NewExpenseProps) => {
   const {
     isOpen: isError,
@@ -79,6 +81,7 @@ export const NewExpenseModal = ({
               selectedExpense={thisExpense}
               onCloseSide={onClose}
               retreatId={retreatId}
+              thisEvent={thisEvent}
             />
           </ModalBody>
         </HStack>

--- a/src/components/NewExpenseModal.tsx
+++ b/src/components/NewExpenseModal.tsx
@@ -14,16 +14,12 @@ import { Expense } from "~/common/types";
 type NewExpenseProps = {
   isOpen: boolean;
   onClose: () => void;
-  expenses: Expense[];
-  setExpenses: (e: Expense[]) => void;
   thisExpense: Expense | undefined;
 };
 
 export const NewExpenseModal = ({
   isOpen,
   onClose,
-  expenses,
-  setExpenses,
   thisExpense,
 }: NewExpenseProps) => {
   const {
@@ -76,8 +72,6 @@ export const NewExpenseModal = ({
             boxShadow={"0px 4px 29px 0px #00000040"}
           >
             <NewExpenseForm
-              expenses={expenses}
-              setExpenses={(e: Expense[]) => setExpenses(e)}
               onOpenError={onOpenError}
               onCloseError={onCloseError}
               selectedExpense={thisExpense}

--- a/src/components/NewExpenseModal.tsx
+++ b/src/components/NewExpenseModal.tsx
@@ -17,6 +17,8 @@ type NewExpenseProps = {
   retreatId?: string;
   thisExpense: Expense | undefined;
   thisEvent?: string;
+  expenses?: Expense[];
+  setExpenses?: (e: Expense[]) => void;
 };
 
 export const NewExpenseModal = ({
@@ -24,7 +26,9 @@ export const NewExpenseModal = ({
   onClose,
   thisExpense,
   retreatId,
-  thisEvent
+  thisEvent,
+  expenses,
+  setExpenses
 }: NewExpenseProps) => {
   const {
     isOpen: isError,
@@ -82,6 +86,8 @@ export const NewExpenseModal = ({
               onCloseSide={onClose}
               retreatId={retreatId}
               thisEvent={thisEvent}
+              expenses={expenses}
+              setExpenses={setExpenses}
             />
           </ModalBody>
         </HStack>

--- a/src/components/NewExpenseModal.tsx
+++ b/src/components/NewExpenseModal.tsx
@@ -14,6 +14,7 @@ import { Expense } from "~/common/types";
 type NewExpenseProps = {
   isOpen: boolean;
   onClose: () => void;
+  retreatId?: string;
   thisExpense: Expense | undefined;
 };
 
@@ -21,6 +22,7 @@ export const NewExpenseModal = ({
   isOpen,
   onClose,
   thisExpense,
+  retreatId,
 }: NewExpenseProps) => {
   const {
     isOpen: isError,
@@ -76,6 +78,7 @@ export const NewExpenseModal = ({
               onCloseError={onCloseError}
               selectedExpense={thisExpense}
               onCloseSide={onClose}
+              retreatId={retreatId}
             />
           </ModalBody>
         </HStack>

--- a/src/components/expenses/ExpenseEntry.tsx
+++ b/src/components/expenses/ExpenseEntry.tsx
@@ -1,17 +1,33 @@
-import { Box, Grid, GridItem } from "@chakra-ui/react";
+import { Box, Grid, GridItem, useDisclosure } from "@chakra-ui/react";
 import { Expense } from "~/common/types";
 import fonts from "~/common/theme/fonts";
-
+import { NewExpenseModal } from "../NewExpenseModal";
 export default function Expense({
+  _id,
   name,
   event,
   type,
   cost,
-  numUnits,
+  numUnits
 }: Expense) {
+  const expense: Expense = {
+    _id: _id,
+    name: name,
+    event: event,
+    type: type,
+    cost: cost,
+    numUnits: numUnits
+  };
+  const {
+    isOpen: isOpenAddExpenseModal,
+    onOpen: onOpenAddExpenseModal,
+    onClose: onCloseAddExpenseModal,
+  } = useDisclosure();
+
   return (
     <>
       <Grid
+        onClick={onOpenAddExpenseModal}
         templateColumns="repeat(9, 1fr)"
         gap={4}
         _hover={{
@@ -49,6 +65,11 @@ export default function Expense({
           <Box fontFamily={fonts.nunito}>${cost * (numUnits || 1)}</Box>
         </GridItem>
       </Grid>
+      <NewExpenseModal
+        isOpen={isOpenAddExpenseModal}
+        onClose={onCloseAddExpenseModal}
+        thisExpense={expense}
+      />
     </>
   );
 }

--- a/src/components/expenses/ExpenseEntry.tsx
+++ b/src/components/expenses/ExpenseEntry.tsx
@@ -2,10 +2,12 @@ import { Box, Grid, GridItem, useDisclosure } from "@chakra-ui/react";
 import { Expense } from "~/common/types";
 import fonts from "~/common/theme/fonts";
 import { NewExpenseModal } from "../NewExpenseModal";
+
 export default function Expense({
   _id,
   name,
   event,
+  eventId,
   type,
   cost,
   numUnits
@@ -14,6 +16,7 @@ export default function Expense({
     _id: _id,
     name: name,
     event: event,
+    eventId: eventId,
     type: type,
     cost: cost,
     numUnits: numUnits
@@ -68,6 +71,7 @@ export default function Expense({
       <NewExpenseModal
         isOpen={isOpenAddExpenseModal}
         onClose={onCloseAddExpenseModal}
+        thisEvent={eventId}
         thisExpense={expense}
       />
     </>

--- a/src/components/expenses/ExpenseGroup.tsx
+++ b/src/components/expenses/ExpenseGroup.tsx
@@ -27,7 +27,7 @@ export default function ExpenseGroup({ title, expenses }: ExpenseGroup) {
           {open ? (
             expenses.map((expense: Expense) => (
               <ExpenseEntry
-                key={expense.name + expense.type + expense.cost + expense.event}
+                key={expense._id + expense.name + expense.type + expense.cost + expense.event}
                 {...expense}
               />
             ))

--- a/src/components/expenses/ExpenseGroup.tsx
+++ b/src/components/expenses/ExpenseGroup.tsx
@@ -27,7 +27,7 @@ export default function ExpenseGroup({ title, expenses }: ExpenseGroup) {
           {open ? (
             expenses.map((expense: Expense) => (
               <ExpenseEntry
-                key={expense._id + expense.name + expense.type + expense.cost + expense.event}
+                key={expense._id + expense.name + expense.type + expense.cost + expense.event + expense.eventId}
                 {...expense}
               />
             ))

--- a/src/pages/retreat-expenses/[id].tsx
+++ b/src/pages/retreat-expenses/[id].tsx
@@ -274,8 +274,6 @@ export default function RetreatExpenses() {
             <NewExpenseModal
               isOpen={isOpenAddExpenseModal}
               onClose={onCloseAddExpenseModal}
-              expenses={[]}
-              setExpenses={() => {}}
               thisExpense={undefined}
             />
           </Box>

--- a/src/pages/retreat-expenses/[id].tsx
+++ b/src/pages/retreat-expenses/[id].tsx
@@ -62,21 +62,46 @@ export default function RetreatExpenses() {
   const router = useRouter();
   const { id: retreatId }: { id?: string } = router.query;
   const eventData = trpc.event.getEvents.useQuery(retreatId!).data;
+  const expenseData = trpc.event.getExpenses.useQuery(retreatId!).data;
 
   const chapter = trpc.chapter.getChapterByRetreatId.useQuery(retreatId!).data;
 
-  const expenses: ExpenseWithDateAndEvent[] =
-    eventData
-      ?.map((event) => {
-        return event.expenses.map((expense) => {
-          return {
-            ...expense,
-            dates: event.dates,
-            event: event.name,
-          };
+  // const expenses: ExpenseWithDateAndEvent[] =
+  //   eventData
+  //     ?.map((event) => {
+  //       return event.expenses.map((expense) => {
+  //         return {
+  //           ...expense,
+  //           dates: event.dates,
+  //           event: event.name,
+  //         };
+  //       });
+  //     })
+  //     ?.flat() ?? [];
+
+  const expenses: ExpenseWithDateAndEvent[] = [];
+
+  if (eventData) {
+    eventData.forEach(event => {
+        event.expenses.forEach(expense => {
+            expenses.push({
+                ...expense,
+                dates: event.dates,
+                event: event.name,
+            });
         });
-      })
-      ?.flat() ?? [];
+    });
+  }
+
+  if (expenseData) {
+    expenseData.forEach(expense => {
+        expenses.push({
+            ...expense,
+            dates: [],
+            event: "General"
+        });
+    });
+  }
 
   const totalCost = expenses.reduce(
     (total, expense) => total + expense.cost * (expense.numUnits || 1),
@@ -275,6 +300,7 @@ export default function RetreatExpenses() {
               isOpen={isOpenAddExpenseModal}
               onClose={onCloseAddExpenseModal}
               thisExpense={undefined}
+              retreatId={retreatId}
             />
           </Box>
         </Flex>

--- a/src/pages/retreat-expenses/[id].tsx
+++ b/src/pages/retreat-expenses/[id].tsx
@@ -32,6 +32,7 @@ function getTotalCost(expense: Expense) {
 type ExpenseWithDateAndEvent = Expense & {
   dates: DateObject[];
   event: string;
+  eventId?: string;
 };
 
 export type ExpenseGroup = {
@@ -88,6 +89,7 @@ export default function RetreatExpenses() {
                 ...expense,
                 dates: event.dates,
                 event: event.name,
+                eventId: event._id
             });
         });
     });

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -34,16 +34,34 @@ export const eventRouter = createTRPCRouter({
       const event = new EventModel({ retreatId, ...eventDetails });
       await event.save();
     }),
+    updateExpense: studentProcedure
+    .input(
+      z.object({
+        expenseId: z.string(),
+        expense: expenseSchema,
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const { expenseId, expense } = input;
+      await ExpenseModel.findByIdAndUpdate(expenseId, expense).exec();
+    }),
     createExpense: studentProcedure
     .input(
       z.object({
+        retreatId: z.string().optional(),
         expenseDetails: expenseSchema,
       }),
     )
     .mutation(async ({ input }) => {
-      const { expenseDetails } = input;
-      const expense = new ExpenseModel({ ...expenseDetails });
-      await expense.save();
+      const { retreatId, expenseDetails } = input;
+      if (retreatId) {
+        const expense = new ExpenseModel({ retreatId, ...expenseDetails });
+        await expense.save();
+      } else {
+        const { expenseDetails } = input;
+        const expense = new ExpenseModel({ ...expenseDetails });
+        await expense.save();
+      }
     }),
   createEventInLatestRetreat: studentProcedure
     .input(
@@ -82,5 +100,9 @@ export const eventRouter = createTRPCRouter({
   getEvents: studentProcedure.input(z.string()).query(async (opts) => {
     const events = await EventModel.find({ retreatId: opts.input }).exec();
     return events;
+  }),
+  getExpenses: studentProcedure.input(z.string()).query(async (opts) => {
+    const expenses = await ExpenseModel.find({ retreatId: opts.input }).exec();
+    return expenses;
   }),
 });

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -45,6 +45,27 @@ export const eventRouter = createTRPCRouter({
       const { expenseId, expense } = input;
       await ExpenseModel.findByIdAndUpdate(expenseId, expense).exec();
     }),
+    updateExpenseByEvent: studentProcedure
+    .input(
+      z.object({
+        expenseId: z.string(),
+        expense: expenseSchema,
+        eventId: z.string()
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const { expenseId, expense, eventId } = input;
+      const event = await EventModel.findById(eventId).exec();
+      if (!event) {
+        throw new Error('Event not found: ' + event);
+      }
+      const expenseIndex = event.expenses.findIndex(exp => exp._id?.toString() === expenseId)
+      if (expenseIndex === -1) {
+        throw new Error('Expense not found with ID: ' + expenseId);
+      }
+      event.expenses[expenseIndex] = expense;
+      await event.save();
+    }),
     createExpense: studentProcedure
     .input(
       z.object({

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eventSchema } from "~/common/types";
+import { eventSchema, expenseSchema } from "~/common/types";
 
 import {
   createTRPCRouter,
@@ -8,7 +8,7 @@ import {
   studentProcedure,
 } from "~/server/api/trpc";
 
-import { EventModel, IEvent } from "~/server/models/Event";
+import {EventModel, ExpenseModel, IEvent } from "~/server/models/Event";
 import { RetreatModel } from "~/server/models/Retreat";
 export const eventRouter = createTRPCRouter({
   updateEvent: studentProcedure
@@ -34,7 +34,17 @@ export const eventRouter = createTRPCRouter({
       const event = new EventModel({ retreatId, ...eventDetails });
       await event.save();
     }),
-
+    createExpense: studentProcedure
+    .input(
+      z.object({
+        expenseDetails: expenseSchema,
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const { expenseDetails } = input;
+      const expense = new ExpenseModel({ ...expenseDetails });
+      await expense.save();
+    }),
   createEventInLatestRetreat: studentProcedure
     .input(
       z.object({

--- a/src/server/models/Event.ts
+++ b/src/server/models/Event.ts
@@ -52,3 +52,7 @@ export const EventSchema = new Schema<IEvent>({
 export const EventModel =
   (mongoose.models.Event as mongoose.Model<IEvent>) ??
   mongoose.model("Event", EventSchema);
+
+export const ExpenseModel =
+  (mongoose.models.Expense as mongoose.Model<IExpense>) ??
+  mongoose.model("Expense", ExpenseSchema);

--- a/src/server/models/Event.ts
+++ b/src/server/models/Event.ts
@@ -4,7 +4,10 @@ import { dateObjectSchema, eventSchema, expenseSchema } from "~/common/types";
 
 const { Schema } = mongoose;
 
-interface IExpense extends z.infer<typeof expenseSchema> {}
+interface IExpense extends z.infer<typeof expenseSchema> {
+  _id: string;
+  retreatId: mongoose.Types.ObjectId;
+}
 interface IEventDate extends z.infer<typeof dateObjectSchema> {}
 
 export interface IEvent extends z.infer<typeof eventSchema> {
@@ -19,13 +22,16 @@ const DateSchema = new Schema<IEventDate>({
 });
 
 export const ExpenseSchema = new Schema<IExpense>({
+  retreatId: {
+    ref: "Retreat",
+    type: Schema.Types.ObjectId
+  },
   name: { type: String, required: true },
   event: { type: String },
   type: { type: String, required: true },
   cost: { type: Number, required: true },
   numUnits: { type: Number },
 });
-
 export const EventSchema = new Schema<IEvent>({
   retreatId: {
     ref: "Retreat",


### PR DESCRIPTION
- Expenses without events:
   - Allowed for optional retreatId to be stored in Expenses
   - Set event to General in display
   - Set dates to empty array for expenses without events
- When adding expenses directly we pass through NewExpenseModal -> NewExpenseForm but when adding an expense in the Calendar page we go directly to NewExpenseForm
- Three cases: editing expense in calendar, editing expense without event in retreat-expenses, editing expense with event in retreat-expenses
