### PR TITLE
Fix/retreat planning and expenses bug fixes

### DIFF
--- a/src/components/Calendar/CalendarContent.tsx
+++ b/src/components/Calendar/CalendarContent.tsx
@@ -94,8 +94,8 @@ export default function CalendarContent({
       };
 
       const totalExpense = currEvent.expenses.reduce(
-        (acc: any, cv: any) => acc + cv.cost,
-        0,
+        (acc: any, cv: any) => acc + (cv.numUnits ? cv.cost * cv.numUnits : cv.cost),
+        0
       );
 
       const event: EventWithStamp = {

--- a/src/components/NewEventModal.tsx
+++ b/src/components/NewEventModal.tsx
@@ -589,9 +589,7 @@ export const NewEventModal = ({
                     fontWeight="400"
                     lineHeight="25px"
                   >{`$${state.event.expenses.reduce(
-                    (acc, cv) =>
-                      acc + cv.cost * (cv.numUnits ? cv.numUnits : 1),
-                    0,
+                    (acc: any, cv: any) => acc + (cv.numUnits ? cv.cost * cv.numUnits : cv.cost),0
                   )}`}</Text>
                 </HStack>
                 {state.event.notes && (

--- a/src/components/NewExpenseForm.tsx
+++ b/src/components/NewExpenseForm.tsx
@@ -81,6 +81,10 @@ export const NewExpenseForm = ({
     });
   const handleCostChange = (event: React.FormEvent<HTMLInputElement>) => {
     if (event.currentTarget.value !== "") {
+      const regex = /^\d*\.?\d{0,2}$/;
+      if (!regex.test(event.currentTarget.value)) {
+        return;
+      }
       dispatch({
         type: "UPDATE_EXPENSE",
         field: "cost",

--- a/src/components/expenses/ExpenseEntry.tsx
+++ b/src/components/expenses/ExpenseEntry.tsx
@@ -62,7 +62,7 @@ export default function Expense({
           <Box fontFamily={fonts.nunito}>${cost}</Box>
         </GridItem>
         <GridItem colSpan={1}>
-          <Box fontFamily={fonts.nunito}>x{numUnits}</Box>
+        <Box fontFamily={fonts.nunito}>{numUnits ? `x${numUnits}` : null}</Box>
         </GridItem>
         <GridItem colSpan={1} display="flex" justifyContent="end">
           <Box fontFamily={fonts.nunito}>

--- a/src/server/models/Event.ts
+++ b/src/server/models/Event.ts
@@ -30,7 +30,7 @@ export const ExpenseSchema = new Schema<IExpense>({
   event: { type: String },
   type: { type: String, required: true },
   cost: { type: Number, required: true },
-  numUnits: { type: Number, required: true },
+  numUnits: { type: Number },
 });
 export const EventSchema = new Schema<IEvent>({
   retreatId: {


### PR DESCRIPTION
I did not see an issue with the last bug listed. Seemed to function correctly but I am not sure.

Also, decimal values that start with .0 immediately clear due to setting a value to float automatically while typing. So while typing 9.01 it automatically sets to 9